### PR TITLE
Build multiarch images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
     resource_class: small
     steps:
       - setup_remote_docker
+      - checkout
       - attach_workspace:
           at: .
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,17 +68,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create data directory
-          command: mkdir -p /data
-      - run:
-          name: Install sqlx-cli
-          command: cargo install sqlx-cli --version 0.7.3 --locked
-      - run:
-          name: SQLX Database Setup
-          command: |
-            cd ./proof-api
-            sqlx database setup
-      - run:
           name: Build release
           command: |
             cd ./proof-api
@@ -90,9 +79,6 @@ jobs:
       - run:
           name: Copy binary to assets
           command: cp ./target/release/main ./assets/proofapi-arm64
-      - run:
-          name: Copy db file to assets
-          command: cp /data/confidential_assets.db ./assets/confidential_assets_arm64.db
       - persist_to_workspace:
           root: ./assets
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - attach_workspace:
-          at: .
+          at: ./assets
       - run: |
           export VERSION=`.docker/scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ workflows:
             branches:
               only:
                 - main
-                - build_multiarch_images
       - build-docker-debian:
           context:
             - DockerHub
@@ -179,7 +178,6 @@ workflows:
             branches:
               only:
                 - main
-                - build_multiarch_images
       - build-docker-arm64-debian:
           context:
             - DockerHub
@@ -191,7 +189,6 @@ workflows:
             branches:
               only:
                 - main
-                - build_multiarch_images
       - push-multiarch-image:
           context:
             - DockerHub
@@ -202,4 +199,3 @@ workflows:
             branches:
               only:
                 - main
-                - build_multiarch_images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,47 @@ jobs:
           paths:
               - .
 
+  build-arm64:
+    docker:
+      - image: polymeshassociation/rust-arm64:debian-nightly-2023-06-01
+    resource_class: arm.xlarge
+    environment:
+      VERBOSE: "1"
+      RUSTFLAGS: -D warnings
+      DATABASE_URL: "sqlite:/data/confidential_assets.db"
+    steps:
+      - checkout
+      - run:
+          name: Create data directory
+          command: mkdir -p /data
+      - run:
+          name: Install sqlx-cli
+          command: cargo install sqlx-cli --version 0.7.3 --locked
+      - run:
+          name: SQLX Database Setup
+          command: |
+            cd ./proof-api
+            sqlx database setup
+      - run:
+          name: Build release
+          command: |
+            cd ./proof-api
+            cargo build --release
+          no_output_timeout: 30m
+      - run:
+          name: Create assets directory for releases
+          command: mkdir ./assets
+      - run:
+          name: Copy binary to assets
+          command: cp ./target/release/main ./assets/proofapi-arm64
+      - run:
+          name: Copy db file to assets
+          command: cp /data/confidential_assets.db ./assets/confidential_assets_arm64.db
+      - persist_to_workspace:
+          root: ./assets
+          paths:
+              - .
+
   build-docker-debian:
     environment:
       IMAGE_NAME: polymeshassociation/polymesh-private-proof-api
@@ -70,15 +111,64 @@ jobs:
           at: ./assets
       - run: |
           export VERSION=`.docker/scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
-          docker build -f ./.docker/Dockerfile.proofapi.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian .
+          docker build -f ./.docker/Dockerfile.proofapi.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian-amd64 --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 .
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker push --all-tags $IMAGE_NAME
+
+  build-docker-arm64-debian:
+    environment:
+      IMAGE_NAME: polymeshassociation/polymesh-private-proof-api
+    docker:
+      - image: cimg/deploy:2023.12
+    # this is the smallest resource class that supports arm64
+    resource_class: arm.medium
+    steps:
+      - setup_remote_docker
+      - checkout
+      - attach_workspace:
+          at: ./assets
+      - run: |
+          export VERSION=`.docker/scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          docker build -f ./.docker/arm64/Dockerfile.proofapi.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian-arm64 --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64 .
+          echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
+          docker push --all-tags $IMAGE_NAME
+
+  push-multiarch-image:
+    environment:
+      IMAGE_NAME: polymeshassociation/polymesh-private-proof-api
+    docker:
+      - image: cimg/deploy:2023.12
+    resource_class: small
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run: |
+          export VERSION=`.docker/scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
+          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian
+          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH
+          # If the branch is main, add manifests with $IMAGE_NAME:$VERSION and $IMAGE_NAME:latest tags
+          if [ "$CIRCLE_BRANCH" == "main" ]; then
+            docker manifest create $IMAGE_NAME:$VERSION --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+            docker manifest create $IMAGE_NAME:latest --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+            docker manifest push $IMAGE_NAME:$VERSION
+            docker manifest push $IMAGE_NAME:latest
+          fi
 
 workflows:
   commit:
     jobs:
       - lint
       - build
+      - build-arm64:
+          filters:
+            branches:
+              only:
+                - main
+                - build_multiarch_images
       - build-docker-debian:
           context:
             - DockerHub
@@ -88,3 +178,27 @@ workflows:
             branches:
               only:
                 - main
+                - build_multiarch_images
+      - build-docker-arm64-debian:
+          context:
+            - DockerHub
+          requires:
+            # this job requires the build job to make sure it has access to all required artifacts in its workspace.
+            - build
+            - build-arm64
+          filters:
+            branches:
+              only:
+                - main
+                - build_multiarch_images
+      - push-multiarch-image:
+          context:
+            - DockerHub
+          requires:
+            - build-docker-debian
+            - build-docker-arm64-debian
+          filters:
+            branches:
+              only:
+                - main
+                - build_multiarch_images

--- a/.docker/arm64/Dockerfile.proofapi.debian
+++ b/.docker/arm64/Dockerfile.proofapi.debian
@@ -1,0 +1,38 @@
+FROM debian:bullseye-slim
+
+RUN apt update && \
+  DEBIAN_FRONTEND=noninteractive apt install \
+  curl \
+  -y --no-install-recommends && \
+  apt autoremove -y && \
+  apt clean
+
+# explicitly set user/group IDs
+RUN set -eux; \
+	groupadd -r proofapi --gid=1000; \
+	useradd -r -g proofapi --uid=1000 -m -d /opt/proofapi proofapi; \
+	mkdir -p /opt/proofapi; \
+	chown -R proofapi:proofapi /opt/proofapi
+
+COPY --chown=root:root ./assets/proofapi-arm64 /usr/local/bin/proofapi
+COPY --chown=proofapi:proofapi ./assets/confidential_assets_arm64.db /data/confidential_assets.db
+COPY --chown=proofapi:proofapi ./LICENSE.pdf /opt/proofapi/LICENSE.pdf
+
+RUN chmod 0755 /usr/local/bin/proofapi
+
+WORKDIR /opt/proofapi
+
+ENV PORT=${PORT:-8080}
+ENV DATABASE_URL=${DATABASE_URL:-sqlite:/data/confidential_assets.db}
+ENV BIND_ADDRESS=${BIND_ADDRESS:-0.0.0.0}
+EXPOSE $PORT
+
+USER proofapi
+
+CMD ["/usr/local/bin/proofapi"]
+
+HEALTHCHECK \
+	--interval=20s \
+	--timeout=3s \
+	--retries=2 \
+  	CMD curl -f http://$BIND_ADDRESS:$PORT/api/health || exit 1

--- a/.docker/arm64/Dockerfile.proofapi.debian
+++ b/.docker/arm64/Dockerfile.proofapi.debian
@@ -15,7 +15,7 @@ RUN set -eux; \
 	chown -R proofapi:proofapi /opt/proofapi
 
 COPY --chown=root:root ./assets/proofapi-arm64 /usr/local/bin/proofapi
-COPY --chown=proofapi:proofapi ./assets/confidential_assets_arm64.db /data/confidential_assets.db
+COPY --chown=proofapi:proofapi ./assets/confidential_assets.db /data/confidential_assets.db
 COPY --chown=proofapi:proofapi ./LICENSE.pdf /opt/proofapi/LICENSE.pdf
 
 RUN chmod 0755 /usr/local/bin/proofapi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-private-proof-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/proof-api/Cargo.toml
+++ b/proof-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-private-proof-api"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "Polymesh Association" ]
 edition = "2021"
 


### PR DESCRIPTION
This changes adds an arm64 docker image build. On top of that it also creates a multiarch docker manifest, which once pushed adds a single image tag to cover both supported architectures. This way, the users won't need to specify the architecture explicitly as it would be matched against their runtime environment as long as it's supported.

In addition if the build happens against the main branch, additional image tags would be created, in total it creates following tags:

- polymeshassociation/polymesh-private-proof-api:[VERSION]-[BRANCH]-debian
- polymeshassociation/polymesh-private-proof-api:[VERSION]-[BRANCH]
- polymeshassociation/polymesh-private-proof-api:[VERSION]
- polymeshassociation/polymesh-private-proof-api:latest

This makes the debian image the default one, which we can modify if we want to add distroless or any other base for the docker image.